### PR TITLE
ACEF-37: Support Sentry Releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aces-server",
-  "version": "1.0.0-alpha.10",
+  "version": "1.0.0-alpha.11",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Bump project version to 1.0.0-alpha.11 in package.json. Refactor Sentry configuration in next.config.mjs, integrating package.json version dynamically and improving concise conditional checks for deployment environments.