### PR TITLE
ACE-104: Allow source maps in Sentry staging environment

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -10,7 +10,7 @@ const nextConfig = {}
 const isSentryEnabled = () => {
   const env = process.env.APP_ENV
 
-  return env === 'production' || (env === 'staging')
+  return env === 'production' || (env === 'staging' && gitRef === 'develop')
 }
 
 const sentryOptions = {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,6 +9,7 @@ const nextConfig = {}
 
 const isSentryEnabled = () => {
   const env = process.env.APP_ENV
+  const gitRef = process.env.VERCEL_GIT_COMMIT_REF
 
   return env === 'production' || (env === 'staging' && gitRef === 'develop')
 }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -8,7 +8,7 @@ const packageJson = JSON.parse(readFileSync('./package.json', 'utf8'))
 const nextConfig = {}
 
 const isSentryEnabled = () => {
-  const env = process.env.VERCEL_ENV
+  const env = process.env.APP_ENV
 
   return env === 'production' || (env === 'staging')
 }
@@ -18,7 +18,7 @@ const sentryOptions = {
   project: process.env.SENTRY_PROJECT,
   silent: !process.env.CI,  // Suppresses Sentry logging during build when not in CI environment
   widenClientFileUpload: true,  // Upload a larger set of source maps for prettier stack traces (increases build time)
-  hideSourceMaps: process.env.VERCEL_ENV === 'production',  // Hides source maps from generated client bundles
+  hideSourceMaps: process.env.APP_ENV === 'production',  // Hides source maps from generated client bundles
   disableLogger: true,  // Automatically tree-shake Sentry logger statements to reduce bundle size
   automaticVercelMonitors: true,  // Enables automatic instrumentation of Vercel Cron Monitors
   release: packageJson.version  // Sets the release version to the version specified in package.json


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Updated Sentry configuration to correctly reference the `APP_ENV` variable for environment checks.
	- Adjusted source map visibility settings in production based on the new environment variable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->