### PR TITLE
ACE-108 Register user as anonymous when appropriate 

### DIFF
--- a/src/lib/hooks/auth/use-register-viewer.tsx
+++ b/src/lib/hooks/auth/use-register-viewer.tsx
@@ -27,7 +27,8 @@ async function fetcher(url: string, viewerData: ViewerData, csrfToken: string) {
 }
 
 function useRegisterViewer(viewerData: ViewerData, user: User | null | undefined) {
-  const shouldRegister = user === null || user?.linearId === null
+  const isAnonymousUser = user === null || user?.linearId === null
+  const shouldRegister = isAnonymousUser
   const { csrfToken, isLoading: csrfLoading, isError: csrfError } = useCsrfToken()
 
   const { data, error, isValidating } = useSWR<User | undefined>(

--- a/src/lib/hooks/auth/use-register-viewer.tsx
+++ b/src/lib/hooks/auth/use-register-viewer.tsx
@@ -27,7 +27,7 @@ async function fetcher(url: string, viewerData: ViewerData, csrfToken: string) {
 }
 
 function useRegisterViewer(viewerData: ViewerData, user: User | null | undefined) {
-  const shouldRegister = user === null
+  const shouldRegister = user === null || user?.linearId === null
   const { csrfToken, isLoading: csrfLoading, isError: csrfError } = useCsrfToken()
 
   const { data, error, isValidating } = useSWR<User | undefined>(

--- a/tests/lib/hooks/auth/use-register-viewer.test.tsx
+++ b/tests/lib/hooks/auth/use-register-viewer.test.tsx
@@ -57,7 +57,49 @@ describe('useRegisterViewer', () => {
     expect(result.current.error).toBeUndefined()
   })
 
+  it('should fetch when user linear ID is null and CSRF token is available', () => {
+    const mockUser = { id: 'user-id', displayName: 'Test User', linearId: null } as User
+    mockUseSWR.mockReturnValue({
+      data: { user: mockUser },
+      error: undefined,
+      isLoading: false,
+      isValidating: false,
+      mutate: jest.fn(),
+    })
+
+    const { result } = renderHook(() => useRegisterViewer(mockViewerData, mockUser))
+
+    expect(mockUseSWR).toHaveBeenCalledWith(
+      ['http://test-api.com/auth/anonymous', mockViewerData, mockCsrfToken],
+      expect.any(Function),
+      expect.any(Object)
+    )
+    expect(result.current.isRegistered).toBe(true)
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.error).toBeUndefined()
+  })
+
   it('should not fetch when user is not null', () => {
+    const mockUser = { id: 'user-id', displayName: 'Test User', linearId: '123' } as User
+
+    mockUseSWR.mockReturnValue({
+      data: undefined,
+      error: undefined,
+      isLoading: false,
+      isValidating: false,
+      mutate: jest.fn(),
+    })
+
+    const { result } = renderHook(() => useRegisterViewer(mockViewerData, mockUser))
+
+    expect(mockUseSWR).toHaveBeenCalledWith(null, expect.any(Function), expect.any(Object))
+    expect(result.current.isRegistered).toBe(false)
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.error).toBeNull()
+    expect(result.current.data).toBeUndefined()
+  })
+
+  it('should not fetch when user linear ID is not null', () => {
     const mockUser = { id: 'user-id', displayName: 'Test User', linearId: '123' } as User
 
     mockUseSWR.mockReturnValue({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded registration criteria for users to include cases where a user object exists but lacks a valid linear ID.
  
- **Tests**
	- Added two new test cases for the `useRegisterViewer` hook to enhance coverage and validate behavior under different user states regarding the linear ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->